### PR TITLE
Fix Docker build for server

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "nest start",
-    "start:dev": "nest start --watch"
+    "start:dev": "nest start --watch",
+    "build": "nest build"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",


### PR DESCRIPTION
## Summary
- add `build` script to `server/package.json`

This allows `yarn build` to run during the Docker image build step.

## Testing
- `docker` is not installed in this environment so docker-compose cannot run