### PR TITLE
Fix Dockerfile config for Yarn 4

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,7 +2,10 @@ FROM node:18
 WORKDIR /app
 COPY package.json .
 COPY yarn.lock* .
-RUN corepack enable && corepack prepare yarn@4.0.0 --activate && yarn install
+RUN corepack enable \
+    && corepack prepare yarn@4.0.0 --activate \
+    && yarn config set nodeLinker node-modules \
+    && yarn install
 COPY . .
 RUN yarn build
 CMD ["node", "dist/main"]


### PR DESCRIPTION
## Summary
- ensure Yarn uses `node-modules` linker during server image build

## Testing
- `docker-compose` *(fails: command not found)*